### PR TITLE
fix: output index issue in `Single|Anyonecanpay` mode

### DIFF
--- a/contracts/otx-sighash-lock/src/validate/sighash_single_acp.rs
+++ b/contracts/otx-sighash-lock/src/validate/sighash_single_acp.rs
@@ -29,12 +29,12 @@ pub(crate) fn validate_sighash_single_anyonecanpay(
     let input_len = input.as_slice().len() as u64;
 
     // output
-    let input_index = get_input_index(&input)?;
-    let output = load_cell(input_index, Source::Output)?;
+    let input_absolute_index = calculate_input_absolute_index(&input)?;
+    let output = load_cell(input_absolute_index, Source::Output)?;
     let output_len = output.as_slice().len() as u64;
 
     // outputs data
-    let output_data = load_cell_data(input_index, Source::Output)?.pack();
+    let output_data = load_cell_data(input_absolute_index, Source::Output)?.pack();
     let output_data_len = output_data.as_slice().len() as u64;
 
     // witness
@@ -69,7 +69,7 @@ pub(crate) fn validate_sighash_single_anyonecanpay(
     verify_pubkey_hash(lib, &message, signature, expected_pubkey_hash)
 }
 
-fn get_input_index(input: &CellInput) -> Result<usize, Error> {
+fn calculate_input_absolute_index(input: &CellInput) -> Result<usize, Error> {
     load_transaction()?
         .raw()
         .inputs()

--- a/contracts/otx-sighash-lock/src/validate/sighash_single_acp.rs
+++ b/contracts/otx-sighash-lock/src/validate/sighash_single_acp.rs
@@ -13,8 +13,9 @@ use alloc::{vec, vec::Vec};
 use ckb_std::{
     ckb_constants::Source,
     ckb_types::bytes::Bytes,
+    ckb_types::packed::CellInput,
     ckb_types::prelude::*,
-    high_level::{load_transaction, load_witness_args},
+    high_level::{load_cell, load_cell_data, load_input, load_transaction, load_witness_args},
 };
 
 pub(crate) fn validate_sighash_single_anyonecanpay(
@@ -23,15 +24,18 @@ pub(crate) fn validate_sighash_single_anyonecanpay(
     signature: &[u8; SIGHASH_ALL_SIGNATURE_SIZE],
     expected_pubkey_hash: &[u8],
 ) -> Result<(), Error> {
-    let tx = load_transaction()?.raw();
-
     // input
-    let input = tx.inputs().get(index).ok_or(Error::Encoding)?;
+    let input = load_input(index, Source::GroupInput)?;
     let input_len = input.as_slice().len() as u64;
 
     // output
-    let output = tx.outputs().get(index).ok_or(Error::Encoding)?;
+    let input_index = get_input_index(&input)?;
+    let output = load_cell(input_index, Source::Output)?;
     let output_len = output.as_slice().len() as u64;
+
+    // outputs data
+    let output_data = load_cell_data(input_index, Source::Output)?.pack();
+    let output_data_len = output_data.as_slice().len() as u64;
 
     // witness
     let witness = load_witness_args(index, Source::GroupInput)?;
@@ -53,6 +57,8 @@ pub(crate) fn validate_sighash_single_anyonecanpay(
     blake2b.update(input.as_slice());
     blake2b.update(&output_len.to_le_bytes());
     blake2b.update(output.as_slice());
+    blake2b.update(&output_data_len.to_le_bytes());
+    blake2b.update(output_data.as_slice());
     blake2b.update(&witness_len.to_le_bytes());
     blake2b.update(&witness_for_digest.as_bytes());
     blake2b.finalize(&mut message);
@@ -61,4 +67,13 @@ pub(crate) fn validate_sighash_single_anyonecanpay(
     add_prefix(SighashMode::SingleAnyoneCanPay as u8, &mut message);
 
     verify_pubkey_hash(lib, &message, signature, expected_pubkey_hash)
+}
+
+fn get_input_index(input: &CellInput) -> Result<usize, Error> {
+    load_transaction()?
+        .raw()
+        .inputs()
+        .into_iter()
+        .position(|i| i.as_bytes() == input.as_bytes())
+        .ok_or(Error::ItemMissing)
 }

--- a/tests/src/helper.rs
+++ b/tests/src/helper.rs
@@ -99,6 +99,10 @@ pub fn sign_sighash_single_acp(
     let output = tx.outputs().get(input_index).unwrap();
     let output_len = output.as_slice().len() as u64;
 
+    // outputs data
+    let output_data = tx.outputs_data().get(input_index).unwrap();
+    let output_data_len = output_data.as_slice().len() as u64;
+
     // witness
     let witness = WitnessArgs::default();
     let zero_lock: Bytes = {
@@ -120,6 +124,8 @@ pub fn sign_sighash_single_acp(
     blake2b.update(input.as_slice());
     blake2b.update(&output_len.to_le_bytes());
     blake2b.update(output.as_slice());
+    blake2b.update(&output_data_len.to_le_bytes());
+    blake2b.update(output_data.as_slice());
     blake2b.update(&witness_len.to_le_bytes());
     blake2b.update(&witness_for_digest.as_bytes());
     blake2b.finalize(&mut message);
@@ -159,6 +165,11 @@ pub fn sign_sighash_all_acp(
     let outputs_count = outputs.len();
     let outputs_len = outputs.as_slice().len() as u64;
 
+    // outputs data
+    let outputs_data = tx.outputs_data();
+    let outputs_data_count = outputs_data.unpack().len() as u64;
+    let outputs_data_len = outputs_data.as_slice().len() as u64;
+
     // witness
     let witness = WitnessArgs::default();
     let zero_lock: Bytes = {
@@ -181,6 +192,9 @@ pub fn sign_sighash_all_acp(
     blake2b.update(&outputs_count.to_le_bytes());
     blake2b.update(&outputs_len.to_le_bytes());
     blake2b.update(outputs.as_slice());
+    blake2b.update(&outputs_data_count.to_le_bytes());
+    blake2b.update(&outputs_data_len.to_le_bytes());
+    blake2b.update(outputs_data.as_slice());
     blake2b.update(&witness_len.to_le_bytes());
     blake2b.update(&witness_for_digest.as_bytes());
 


### PR DESCRIPTION
Fix 2 bugs found：

* For Source:GroupInput index, the absolute index needs to be calculated to find the corresponding output
* The output_data is missed in the hash calculation process
