### PR TITLE
refactor: improve the efficiency of loops

### DIFF
--- a/contracts/otx-sighash-lock/src/error.rs
+++ b/contracts/otx-sighash-lock/src/error.rs
@@ -9,7 +9,6 @@ pub enum Error {
     Encoding,
     // Add customized errors here...
     UnsupportedSighashMode,
-    LoopGroupInputs,
     Secp256k1,
     WrongPubkey,
     LoadPrefilledData,

--- a/contracts/otx-sighash-lock/src/helper.rs
+++ b/contracts/otx-sighash-lock/src/helper.rs
@@ -19,7 +19,7 @@ use ckb_std::{
 pub(crate) fn get_signature_mode_by_witness(
     index: usize,
 ) -> Result<([u8; SIGHASH_ALL_SIGNATURE_SIZE], SighashMode), Error> {
-    let witness_args = load_witness_args(index, Source::GroupInput)?;
+    let witness_args = load_witness_args(index, Source::Input)?;
     let witness_lock: Bytes = witness_args
         .lock()
         .to_opt()


### PR DESCRIPTION
use the following code to get the absolute index of all the inputs in the group at once：

```rust
let group_inputs_absolute_indices: Vec<_> = QueryIter::new(load_cell_lock_hash, Source::Input)
    .enumerate()
    .filter_map(|(i, hash)| {
        if hash == current_script_hash {
            Some(i)
        } else {
            None
        }
    })
    .collect();
```

- Loop traversal no longer relies on error definition `IndexOutOfBound`
- This avoids having to find the absolute index for each input：

```rust
fn calculate_input_absolute_index(input: &CellInput) -> Result<usize, Error> {
    load_transaction()?
        .raw()
        .inputs()
        .into_iter()
        .position(|i| i.as_bytes() == input.as_bytes())
        .ok_or(Error::ItemMissing)
}
```